### PR TITLE
Clarify REGISTRY_ credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ jobs:
             location: 'west us'
 ```
 
+**NOTE**: The registry credentials used in the example above (secrets `REGISTRY_USERNAME` and `REGISTRY_PASSWORD`) is the Azure container registry [Admin account](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-authentication#admin-account), which needs to be enabled via Azure portal.
+
 ## Example YAML Snippets
 
 ### Deploying a Container from a public registry


### PR DESCRIPTION
Small clarification regarding the Docker repository credentials used in the example.

It was not obvious to me which credentials to use. I first tried with the samt service principal's credentials as with `az container create` - but did not get that to work.

Maybe this can help others as well.