### PR TITLE
Environment Variables separation logic

### DIFF
--- a/lib/taskparameters.js
+++ b/lib/taskparameters.js
@@ -117,7 +117,7 @@ class TaskParameters {
         if (environmentVariables) {
             let keyValuePairs = environmentVariables.split(' ');
             keyValuePairs.forEach((pair) => {
-                let pairList = pair.split('=');
+                let pairList = pair.split(/=(.+)/);
                 let obj = { "name": pairList[0], "value": pairList[1] };
                 this._environmentVariables.push(obj);
             });
@@ -125,7 +125,7 @@ class TaskParameters {
         if (secureEnvironmentVariables) {
             let keyValuePairs = secureEnvironmentVariables.split(' ');
             keyValuePairs.forEach((pair) => {
-                let pairList = pair.split('=');
+                let pairList = pair.split(/=(.+)/);
                 let obj = { "name": pairList[0], "secureValue": pairList[1] };
                 this._environmentVariables.push(obj);
             });

--- a/src/taskparameters.ts
+++ b/src/taskparameters.ts
@@ -139,7 +139,7 @@ export class TaskParameters {
         if(environmentVariables) {
             let keyValuePairs = environmentVariables.split(' ');
             keyValuePairs.forEach((pair: string) => {
-                let pairList = pair.split('=');
+                let pairList = pair.split(/=(.+)/);
                 let obj: ContainerInstanceManagementModels.EnvironmentVariable = { "name": pairList[0], "value": pairList[1] };
                 this._environmentVariables.push(obj);
             })
@@ -147,7 +147,7 @@ export class TaskParameters {
         if(secureEnvironmentVariables) {
             let keyValuePairs = secureEnvironmentVariables.split(' ');
             keyValuePairs.forEach((pair: string) => {
-                let pairList = pair.split('=');
+                let pairList = pair.split(/=(.+)/);
                 let obj: ContainerInstanceManagementModels.EnvironmentVariable = { "name": pairList[0], "secureValue": pairList[1] };
                 this._environmentVariables.push(obj);
             })


### PR DESCRIPTION
I had a secret like "foobarbaz123=" and tried to use it with this aci-create-action. But after I deployed an application on container, I noticed that the last '=' part of my variable was lost because of the logic below.
```
let pairList = pair.split('=');
```
The logic has to split string only on first instance of '='.