### PR TITLE
Environment Variable Separation logic

### DIFF
--- a/lib/taskparameters.js
+++ b/lib/taskparameters.js
@@ -115,7 +115,8 @@ class TaskParameters {
     }
     _getEnvironmentVariables(environmentVariables, secureEnvironmentVariables) {
         if (environmentVariables) {
-            let keyValuePairs = environmentVariables.split(' ');
+            // split on whitespace, but ignore the ones that are enclosed in quotes
+            let keyValuePairs = environmentVariables.match(/(?:[^\s"]+|"[^"]*")+/g) || []
             keyValuePairs.forEach((pair) => {
                 let pairList = pair.split(/=(.+)/);
                 let obj = { "name": pairList[0], "value": pairList[1] };
@@ -123,7 +124,8 @@ class TaskParameters {
             });
         }
         if (secureEnvironmentVariables) {
-            let keyValuePairs = secureEnvironmentVariables.split(' ');
+            // split on whitespace, but ignore the ones that are enclosed in quotes
+            let keyValuePairs = secureEnvironmentVariables.match(/(?:[^\s"]+|"[^"]*")+/g) || []
             keyValuePairs.forEach((pair) => {
                 let pairList = pair.split(/=(.+)/);
                 let obj = { "name": pairList[0], "secureValue": pairList[1] };

--- a/lib/taskparameters.js
+++ b/lib/taskparameters.js
@@ -117,7 +117,7 @@ class TaskParameters {
         if (environmentVariables) {
             let keyValuePairs = environmentVariables.split(' ');
             keyValuePairs.forEach((pair) => {
-                let pairList = pair.split('=');
+                let pairList = pair.split(/=(.+)/);
                 let obj = { "name": pairList[0], "value": pairList[1] };
                 this._environmentVariables.push(obj);
             });
@@ -125,7 +125,7 @@ class TaskParameters {
         if (secureEnvironmentVariables) {
             let keyValuePairs = secureEnvironmentVariables.split(' ');
             keyValuePairs.forEach((pair) => {
-                let pairList = pair.split('=');
+                let pairList = pair.split(/=(.+)/);
                 let obj = { "name": pairList[0], "secureValue": pairList[1] };
                 this._environmentVariables.push(obj);
             });

--- a/lib/taskparameters.js
+++ b/lib/taskparameters.js
@@ -116,19 +116,27 @@ class TaskParameters {
     _getEnvironmentVariables(environmentVariables, secureEnvironmentVariables) {
         if (environmentVariables) {
             // split on whitespace, but ignore the ones that are enclosed in quotes
-            let keyValuePairs = environmentVariables.match(/(?:[^\s"]+|"[^"]*")+/g) || []
+            let keyValuePairs = environmentVariables.match(/(?:[^\s"]+|"[^"]*")+/g) || [];
             keyValuePairs.forEach((pair) => {
-                let pairList = pair.split(/=(.+)/);
-                let obj = { "name": pairList[0], "value": pairList[1] };
+                // value is either wrapped in quotes or not
+                let pairList = pair.split(/=(?:"(.+)"|(.+))/);
+                let obj = { 
+                    "name": pairList[0], 
+                    "value": pairList[1] || pairList[2]
+                };
                 this._environmentVariables.push(obj);
             });
         }
         if (secureEnvironmentVariables) {
             // split on whitespace, but ignore the ones that are enclosed in quotes
-            let keyValuePairs = secureEnvironmentVariables.match(/(?:[^\s"]+|"[^"]*")+/g) || []
+            let keyValuePairs = secureEnvironmentVariables.match(/(?:[^\s"]+|"[^"]*")+/g) || [];
             keyValuePairs.forEach((pair) => {
-                let pairList = pair.split(/=(.+)/);
-                let obj = { "name": pairList[0], "secureValue": pairList[1] };
+                // value is either wrapped in quotes or not
+                let pairList = pair.split(/=(?:"(.+)"|(.+))/);
+                let obj = { 
+                    "name": pairList[0], 
+                    "value": pairList[1] || pairList[2]
+                };
                 this._environmentVariables.push(obj);
             });
         }

--- a/src/taskparameters.ts
+++ b/src/taskparameters.ts
@@ -138,19 +138,27 @@ export class TaskParameters {
     private _getEnvironmentVariables(environmentVariables: string, secureEnvironmentVariables: string) {
         if(environmentVariables) {
             // split on whitespace, but ignore the ones that are enclosed in quotes
-            let keyValuePairs = environmentVariables.match(/(?:[^\s"]+|"[^"]*")+/g) || []
+            let keyValuePairs = environmentVariables.match(/(?:[^\s"]+|"[^"]*")+/g) || [];
             keyValuePairs.forEach((pair: string) => {
-                let pairList = pair.split(/=(.+)/);
-                let obj: ContainerInstanceManagementModels.EnvironmentVariable = { "name": pairList[0], "value": pairList[1] };
+                // value is either wrapped in quotes or not
+                let pairList = pair.split(/=(?:"(.+)"|(.+))/);
+                let obj: ContainerInstanceManagementModels.EnvironmentVariable = { 
+                    "name": pairList[0], 
+                    "value": pairList[1] || pairList[2]
+                };
                 this._environmentVariables.push(obj);
             })
         }
         if(secureEnvironmentVariables) {
             // split on whitespace, but ignore the ones that are enclosed in quotes
-            let keyValuePairs = secureEnvironmentVariables.match(/(?:[^\s"]+|"[^"]*")+/g) || []
+            let keyValuePairs = secureEnvironmentVariables.match(/(?:[^\s"]+|"[^"]*")+/g) || [];
             keyValuePairs.forEach((pair: string) => {
-                let pairList = pair.split(/=(.+)/);
-                let obj: ContainerInstanceManagementModels.EnvironmentVariable = { "name": pairList[0], "secureValue": pairList[1] };
+                // value is either wrapped in quotes or not
+                let pairList = pair.split(/=(?:"(.+)"|(.+))/);
+                let obj: ContainerInstanceManagementModels.EnvironmentVariable = { 
+                    "name": pairList[0], 
+                    "value": pairList[1] || pairList[2]
+                };
                 this._environmentVariables.push(obj);
             })
         }

--- a/src/taskparameters.ts
+++ b/src/taskparameters.ts
@@ -139,7 +139,7 @@ export class TaskParameters {
         if(environmentVariables) {
             let keyValuePairs = environmentVariables.split(' ');
             keyValuePairs.forEach((pair: string) => {
-                let pairList = pair.split('=');
+                let pairList = pair.split(/=(.+)/);
                 let obj: ContainerInstanceManagementModels.EnvironmentVariable = { "name": pairList[0], "value": pairList[1] };
                 this._environmentVariables.push(obj);
             })
@@ -147,7 +147,7 @@ export class TaskParameters {
         if(secureEnvironmentVariables) {
             let keyValuePairs = secureEnvironmentVariables.split(' ');
             keyValuePairs.forEach((pair: string) => {
-                let pairList = pair.split('=');
+                let pairList = pair.split(/=(.+)/);
                 let obj: ContainerInstanceManagementModels.EnvironmentVariable = { "name": pairList[0], "secureValue": pairList[1] };
                 this._environmentVariables.push(obj);
             })

--- a/src/taskparameters.ts
+++ b/src/taskparameters.ts
@@ -137,7 +137,8 @@ export class TaskParameters {
 
     private _getEnvironmentVariables(environmentVariables: string, secureEnvironmentVariables: string) {
         if(environmentVariables) {
-            let keyValuePairs = environmentVariables.split(' ');
+            // split on whitespace, but ignore the ones that are enclosed in quotes
+            let keyValuePairs = environmentVariables.match(/(?:[^\s"]+|"[^"]*")+/g) || []
             keyValuePairs.forEach((pair: string) => {
                 let pairList = pair.split(/=(.+)/);
                 let obj: ContainerInstanceManagementModels.EnvironmentVariable = { "name": pairList[0], "value": pairList[1] };
@@ -145,7 +146,8 @@ export class TaskParameters {
             })
         }
         if(secureEnvironmentVariables) {
-            let keyValuePairs = secureEnvironmentVariables.split(' ');
+            // split on whitespace, but ignore the ones that are enclosed in quotes
+            let keyValuePairs = secureEnvironmentVariables.match(/(?:[^\s"]+|"[^"]*")+/g) || []
             keyValuePairs.forEach((pair: string) => {
                 let pairList = pair.split(/=(.+)/);
                 let obj: ContainerInstanceManagementModels.EnvironmentVariable = { "name": pairList[0], "secureValue": pairList[1] };


### PR DESCRIPTION
This PR is based on #10 

## Splitting '='

Fix by @yuhattor - only split the first instance of '=' instead of all.
Edit: Added another logic to parse values with optional quotes around them.

Original
```js
"key=foobarbaz123=".split('=')
>> Array(3) [ "key", "foobarbaz123", "" ]
```
Modified
```js
"key=foobarbaz123=".split(/=(?:"(.+)"|(.+))/)
>> Array(3) [ "key", "foobarbaz123=", "" ]
```

Original
```js
"key=\"foo bar baz 123\"=".split('=')
>> Array(3) [ "key", "\"foo bar baz 123\"", "" ]
```
Modified
```js
"key=\"foo bar baz 123=\"".split(/=(?:"(.+)"|(.+))/)
>> Array(4) [ "key", "foo bar baz 123=", undefined, "" ]
```

## Splitting whitespace

New fix - do not account for whitespaces that are inside quotes while splitting.

Original
```js
"key1=\"foo bar\" key2=baz".split(' ');
>> Array(3) [ "key1=\"foo", "bar\"", "key2=baz" ]
```

Modified
```js
"key1=\"foo bar\" key2=baz".match(/(?:[^\s"]+|"[^"]*")+/g) || []
>> Array [ "key1=\"foo bar\"", "key2=baz" ]
```