### PR TITLE
use secureValue for secure env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ jobs:
 
 ### Deploying a Container with Environment Variables and Command Line
 
-**NOTE**: Secure Environment Variables aren't masked by the Action so use them as Secrets if you want to hide them
+**NOTE**: The values of ```secure-environment-variables``` will not be shown in the properties of the Azure Container Instance, but **will** be shown in the logs of the GitHub Action unless you specify them as Secrets.
 
 ```yaml
 - uses: Azure/aci-deploy@v1

--- a/src/taskparameters.ts
+++ b/src/taskparameters.ts
@@ -159,7 +159,7 @@ export class TaskParameters {
                 let pairList = pair.split(/=(?:"(.+)"|(.+))/);
                 let obj: ContainerInstanceManagementModels.EnvironmentVariable = { 
                     "name": pairList[0], 
-                    "value": pairList[1] || pairList[2]
+                    "secureValue": pairList[1] || pairList[2]
                 };
                 this._environmentVariables.push(obj);
             })


### PR DESCRIPTION
```ContainerInstanceManagementModels.EnvironmentVariable``` has a property ```secureValue``` which should be used for secure environment variables. The other property ```value``` is used for non-secure environment variables.

This should address #47 